### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,3 +1,3 @@
-dls-controls git@github.com:dls-controls/ADPcoWin.git
+DiamondLightSource git@github.com:DiamondLightSource/ADPcoWin.git
 upstream git@github.com:areaDetector/ADPcoWin.git
 


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/ADPcoWin` using https://gitlab.diamond.ac.uk/github/github-scripts